### PR TITLE
Add interactive mode

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,7 +9,7 @@ jobs:
         os: ["windows-latest", "ubuntu-latest", "macOS-latest"]
     runs-on: ${{ matrix.os }}
     env:
-      GO_VERSION: 1.19
+      GO_VERSION: 1.21
     steps:
       - uses: actions/checkout@v3
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ bin/*
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -13,16 +13,19 @@ Let's say you have a AWS CLI profile for your IAM user configured. Now to create
 
 ```mfaprof -code <YOUR_MFA_TOKEN_CODE>```
 
+*Tip:* The tool will ask for the code interactively if `-code` flag is not specified.
+
 With this arguments the tool will go ahead and get the first MFA device serial number, authenticate using the provided code and credentials configured in the currently active profile and create a new profile called `<YOUR_PROFILE_NAME>_mfa` with temporary credentials. `YOUR_PROFILE_NAME` is whatever is set in `AWS_PROFILE` environment variable or "default". You can also specify the profile name explicitly with `-profile` argument. 
 
 *Tip:* if you want to use the new profile straight away you need to set `AWS_PROFILE` environment variable. The tool will output a command to do that.
 
 The tool supports the following arguments:
-- `-code` - (Madnatory) The value provided by the MFA device.
+- `-code` - (Optional) The value provided by the MFA device. When omitted, an interactive prompt is shown.
 - `-profile` - (Optional) Name of the AWS CLI profile to authenticate. If not specified, AWS SDK determines the value.
 - `-device` - (Optional) Either the serial number for a hardware device or an ARN for a virtual device. Default: the first MFA device from ListMFADevices API call.
 - `-name` - (Optional) Name of the resulting AWS CLI profile. Default: current or specified AWS CLI profile name + _mfa.
-- `-debug` - (Optional) Enables debug messages.
+- `-debug` - (Optional) Enables debug messages, ignores quiet flag.
+- `-quiet` - (Optional) Suppress non-debug messages.
 
 Due to how Go's `flag` package works, arguments can also start with double dashes.
 
@@ -34,4 +37,4 @@ Due to how Go's `flag` package works, arguments can also start with double dashe
 Being a security tool, `mfaprof` doesn't use any 3rd party code besides AWS SDK. This is to mitigate the risk of vulnerabilities in dependencies.
 
 ### Limitations
-The tool assumes that IAM's ListMFADevices API operation is available to the user without the MFA confition. If not, please provide MFA device serial explicitly.
+The tool assumes that IAM's ListMFADevices API operation is available to the user without the MFA condition. If not, please provide MFA device serial explicitly.

--- a/main.go
+++ b/main.go
@@ -16,12 +16,13 @@ import (
 )
 
 const (
-	defaultNameSuffix        = "_mfa"
-	awsMfaCodePattern        = `^\d{6,6}$`
-	awsMfaDevicePattern      = `^[\w+=/:,.@-]{9,256}$`
-	awsCliProfileNamePattern = `^[\w-]+$`
-	awsProfileSectionPattern = `\[(profile )?%s\]`
-	awsDefaultProfile        = "default"
+	defaultNameSuffix               = "_mfa"
+	awsMfaCodePattern               = `^\d{6,6}$`
+	awsMfaDevicePattern             = `^[\w+=/:,.@-]{9,256}$`
+	awsCliProfileNamePattern        = `^[\w-]+$`
+	awsNamedProfileSectionPattern   = `\[profile %s\]`
+	awsDefaultProfileSectionPattern = `\[default\]`
+	awsDefaultProfile               = "default"
 )
 
 var (
@@ -100,7 +101,13 @@ func validateFlags(opt *options, configFilename string) error {
 	if err != nil {
 		return fmt.Errorf("%w: %v", errSharedConfigUnavailable, err)
 	}
-	profileExists, err := regexp.Match(fmt.Sprintf(awsProfileSectionPattern, opt.profile), cfgFile)
+	var profilePattern string
+	if opt.profile != awsDefaultProfile {
+		profilePattern = fmt.Sprintf(awsNamedProfileSectionPattern, opt.profile)
+	} else {
+		profilePattern = awsDefaultProfileSectionPattern
+	}
+	profileExists, err := regexp.Match(profilePattern, cfgFile)
 	if err != nil {
 		return fmt.Errorf("%w: %v", errCannotParseConfig, err)
 	}

--- a/test/config
+++ b/test/config
@@ -1,4 +1,4 @@
-[profile default]
+[default]
 region = us-east-1
 
 [profile named]


### PR DESCRIPTION
Changes in this branch:
1. Go version update from 1.19 to 1.21
2. Interactive mode. When -code flag is omitted, the prompt is shown. Addresses #1 
3. Quiet mode. Use -quiet to suppress all messages. Ignored if -debug is specified.
4. Bugfix: proper handling of default profile.